### PR TITLE
Implement Frontend Rendering For Dynamic and Home Pages

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Media;
 use App\Models\Page;
+use App\Traits\RequestResponseTrait;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -13,6 +14,8 @@ use Intervention\Image\ImageManager;
 use Intervention\Image\Drivers\Gd\Driver as GdDriver;
 class PageController extends Controller
 {
+    use RequestResponseTrait;
+    
     public function index()
     {
         return response('index');
@@ -39,11 +42,12 @@ class PageController extends Controller
                 $this->createPageSections($request, $page);
             }
             DB::commit();
-            return response()->json(['message' => 'Page created successfully.']);
+
+            $responseMessage = 'Page created successfully.';
+            return $this->successJsonResponse($responseMessage);
         } catch (Exception $error) {
             DB::rollback();
-            \Log::info(['pageError' => $error->getMessage()]);
-            return response()->json(['message' => $error->getMessage()]);
+            return $this->exceptionJsonResponse($error);
         }
     }
 
@@ -99,7 +103,13 @@ class PageController extends Controller
 
     public function parentPages()
     {
-        $parents = Page::where('is_parent', 1)->select('id', 'title')->get();
-        return response()->json($parents);
+        try {
+            $parents = Page::where('is_parent', 1)->select('id', 'title')->get();
+
+            $responseMessage = 'Parent page list loaded successfully.';
+            return $this->successJsonResponse($responseMessage,$parents);
+        } catch (Exception $error) {
+            return $this->exceptionJsonResponse($error);
+        }
     }
 }

--- a/app/Http/Controllers/Frontend/PageController.php
+++ b/app/Http/Controllers/Frontend/PageController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Http\Controllers\Frontend;
+
+use App\Http\Controllers\Controller;
+use App\Models\Page;
+use App\Traits\RequestResponseTrait;
+use Exception;
+use Illuminate\Support\Str;
+
+class PageController extends Controller
+{
+    use RequestResponseTrait;
+
+    public function showPage($slug)
+    {
+        try {
+            $page = Page::select('id', 'title', 'slug', 'is_parent')->where('slug', $slug)->with(['sections:id,page_id,layout_type,description,media_id','sections.media:id,path,alt_text'])->firstOrFail();
+
+            $data = [];
+            $data['id'] = $page->id;
+            $data['title'] = $page->title;
+            $data['slug'] = $page->slug;
+            $data['is_parent'] = $page->is_parent;
+
+            foreach($page->sections as $section) {
+                $data['sections'][] = [
+                    'layout_type' => $section->layout_type,
+                    'description' => $section->description ?? '',
+                    'image_path' => $section->media->path ?? null,
+                    'image_alt_text' => $section->media->alt_text ?? null,
+                ];
+            }
+            $responseMessage = 'Page loaded successfully.';
+            return $this->successJsonResponse($responseMessage,$data);
+        } catch (Exception $error) {
+            return $this->exceptionJsonResponse($error);
+        }
+    }
+
+    public function getChildPages($id)
+    {
+        try {
+            $childPageList = Page::select('id', 'title', 'slug', 'is_parent')->where('parent_id', $id)->with(['sections:id,page_id,layout_type,description,media_id','sections.media:id,path,alt_text'])->get();
+
+            $data = [];
+            foreach($childPageList as $childPage) {
+                $data[] = [
+                    'id' => $childPage->id,
+                    'title' => $childPage->title,
+                    'slug' => $childPage->slug,
+                    'description' => Str::limit($childPage->sections[0]->description ?? '', 100),
+                    'image_path' => $childPage->sections[0]->media->path ?? null,
+                    'image_alt_text' => $childPage->sections[0]->media->alt_text ?? null,
+                ];
+            }
+            $responseMessage = 'Child page loaded successfully.';
+            return $this->successJsonResponse($responseMessage,$data);
+        } catch (Exception $error) {
+            return $this->exceptionJsonResponse($error);
+        }
+    }
+
+    public function getHomePageSections()
+    {
+        try {
+            $pages = Page::select('id', 'title', 'slug', 'parent_id')
+                    ->where('add_to_home', true)
+                    ->with([
+                        'sections' => function ($query) {
+                            $query->select('id', 'page_id', 'layout_type', 'description', 'media_id')
+                            ->with('media:id,path,alt_text');
+                        }
+                    ])
+                    ->get();
+
+            $parentIds = $pages->whereNotNull('parent_id')->pluck('parent_id')->unique();
+            $sectionGrouped = [
+                'single' => [],
+                'parent' => []
+            ];
+
+            foreach ($pages as $page) {
+                if ($page->parent_id) {
+                    continue;
+                }
+
+                if ($parentIds->contains($page->id)) {
+                    $children = $pages->where('parent_id', $page->id)->map(function($child) {
+                        return $this->formatPageData($child);
+                    })->values();
+                    $sectionGrouped['parent'][] = [
+                        'parent_id' => $page->id,
+                        'parent_page_title' => $page->title,
+                        'children' => $children
+                    ];
+                } else {
+                    $sectionGrouped['single'][] = $this->formatPageData($page,400);
+                }
+            }
+
+            $responseMessage ='Home pages fetched successfully.';
+            return $this->successJsonResponse($responseMessage,$sectionGrouped);
+        } catch (Exception $error) {
+            return $this->exceptionJsonResponse($error);
+        }
+
+    }
+
+    private function formatPageData($page, $limit=100)
+    {
+        $firstSection = $page->sections->first();
+        $media = $firstSection->media ?? null;
+
+        return [
+            'id' => $page->id,
+            'title' => $page->title,
+            'slug' => $page->slug,
+            'layout_type' => $firstSection->layout_type,
+            'description' => Str::limit($firstSection->description ?? '', $limit),
+            'image_path' => $media->path ?? null,
+            'image_alt_text' => $media->alt_text ?? null,
+        ];
+    }
+}

--- a/app/Models/PageSections.php
+++ b/app/Models/PageSections.php
@@ -11,4 +11,10 @@ class PageSections extends Model
     public function page() {
         return $this->belongsTo(Page::class);
     }
+
+    public function media()
+    {
+        return $this->hasOne(Media::class, 'id', 'media_id');
+    }
+
 }

--- a/app/Traits/RequestResponseTrait.php
+++ b/app/Traits/RequestResponseTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Traits;
+
+trait RequestResponseTrait
+{
+    public function successJsonResponse($responseMessage,$responseData=null)
+    {
+        return response()->json([
+            'code' => 200,
+            'status' => 'success',
+            'message' => $responseMessage,
+            'content' => $responseData
+        ]);
+    }
+
+    public function exceptionJsonResponse($responseData)
+    {
+        \Log::info(['pageError' => $responseData->getMessage()]);
+        return response()->json([
+            'code' => 500,
+            'status' => 'error',
+            'message' => 'Something went wrong.',
+            'content' => $responseData->getMessage()
+        ]);
+    }
+}

--- a/frontend/src/components/frontend/FrontendBreadcrumb.vue
+++ b/frontend/src/components/frontend/FrontendBreadcrumb.vue
@@ -1,0 +1,33 @@
+<template>
+    <div class="bg-secondary text-white py-4 mb-4">
+        <div class="container">
+            <div class="row">
+            <div class="col-md-12">
+                <h1 class="mb-2">{{ title }}</h1>
+                <ol class="breadcrumb mb-0">
+                    <li v-for="(item, index) in breadcrumb" :key="index" class="breadcrumb-item">
+                        <router-link :to="item.path">{{ item.name }}</router-link>
+                    </li>
+                    <li class="breadcrumb-item active">{{ title }}</li>
+                </ol>
+            </div>
+            </div>
+        </div>
+    </div>
+
+</template>
+
+<script>
+export default {
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    breadcrumb: {
+      type: Array,
+      required: true,
+    },
+  },
+};
+</script>

--- a/frontend/src/components/frontend/FrontendFooter.vue
+++ b/frontend/src/components/frontend/FrontendFooter.vue
@@ -1,0 +1,8 @@
+<template>
+    <!-- Footer Section -->
+    <section class="contact-section text-center bg-dark text-white py-4">
+        <div class="container">
+            <h2>Footer</h2>
+        </div>
+    </section>
+</template>

--- a/frontend/src/components/frontend/FrontendHeader.vue
+++ b/frontend/src/components/frontend/FrontendHeader.vue
@@ -1,0 +1,57 @@
+<template>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">Navbar</a>
+      <button
+        class="navbar-toggler"
+        type="button"
+        data-bs-toggle="collapse"
+        data-bs-target="#navbarSupportedContent"
+        aria-controls="navbarSupportedContent"
+        aria-expanded="false"
+        aria-label="Toggle navigation"
+      >
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item">
+            <router-link :to="`/`" class="nav-link active">
+                Home
+            </router-link>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Link</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a
+              class="nav-link dropdown-toggle"
+              href="#"
+              id="navbarDropdown"
+              role="button"
+              data-bs-toggle="dropdown"
+              aria-expanded="false"
+            >
+              Dropdown
+            </a>
+            <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+              <li><a class="dropdown-item" href="#">Action</a></li>
+              <li><a class="dropdown-item" href="#">Another action</a></li>
+              <li><hr class="dropdown-divider" /></li>
+              <li><a class="dropdown-item" href="#">Something else here</a></li>
+            </ul>
+          </li>
+          <li class="nav-item">
+            <a
+              class="nav-link disabled"
+              href="#"
+              tabindex="-1"
+              aria-disabled="true"
+              >Disabled</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+</template>

--- a/frontend/src/components/frontend/sections/HomePageSectionParent.vue
+++ b/frontend/src/components/frontend/sections/HomePageSectionParent.vue
@@ -1,0 +1,47 @@
+<template>
+     <div>
+        <section class="page-sections container mb-5" v-for="childPageList in parentPageList" :key="childPageList.parent_id">
+            <div class="row mb-3">
+                <div class="d-flex justify-content-center">
+                    <span class="border-bottom border-info-subtle border-5 bg-light ps-2"><h2>{{ childPageList.parent_page_title }}</h2></span>
+                </div>
+            </div>
+            <div class="row album py-5 px-5 bg-light">
+                <div class="col-md-4" v-for="childPage in childPageList.children" :key="childPage.id">
+                    <div class="card" style="width: 18rem;">
+                        <img class="img-fluid card-img-top page-card-image" v-if="childPage.image_path" :src="getImageUrl(childPage.image_path)" :alt="childPage.image_alt_text">
+                        <div class="card-body">
+                            <h5 class="card-title">{{ childPage.title }}</h5>
+                            <p class="card-text" v-html="childPage.description"></p>
+                            <router-link :to="childPage.slug" class="btn btn-primary">{{ buttonName }}</router-link>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+     </div>
+</template>
+
+<script>
+export default{
+    props: ['parentPageList'],
+    data() {
+        return {
+            buttonName: 'Read More'
+        }
+    },
+    methods: {
+        getImageUrl(path) {
+            const baseUrl = process.env.VUE_APP_ASSET_BASE_URL;
+            return `${baseUrl}/storage/${path}`;
+        },
+    }
+}
+</script>
+
+<style scoped>
+    .card-img-top {
+        height: 200px;
+        object-fit: cover;
+    }
+</style>

--- a/frontend/src/components/frontend/sections/HomePageSectionSingle.vue
+++ b/frontend/src/components/frontend/sections/HomePageSectionSingle.vue
@@ -1,0 +1,26 @@
+<template>
+    <div>
+        <div v-for="page in singlePageList" :key="page.id" class="row mb-3">
+            <div class="row mb-3">
+                <div class="d-flex justify-content-start">
+                    <span class="border-start border-info-subtle border-5 bg-light ps-2"><h2>{{ page.title }}</h2></span>
+                </div>
+            </div>
+            <StandardPageSection :section="page" :fromHome="true" />
+        </div>
+    </div>
+</template>
+
+<script>
+import StandardPageSection from "@/components/frontend/sections/StandardPageSection.vue";
+
+export default{
+    props: ['singlePageList'],
+    components: {
+        StandardPageSection,
+    },
+    data() {
+        return {}
+    }
+}
+</script>

--- a/frontend/src/components/frontend/sections/StandardPageSection.vue
+++ b/frontend/src/components/frontend/sections/StandardPageSection.vue
@@ -1,0 +1,68 @@
+<template>
+    <section v-if="section.layout_type==2" :class="['mb-5', fromHome ? 'album py-5 px-5 bg-light' : '']">
+        <div class="row">
+            <div class="col-md-6" v-html="section.description"></div>
+            <div class="col-md-6">
+                <img :class="['img-fluid', fromHome ? 'section-layout-home' : 'section-layout-optional']" v-if="section.image_path" :src="getImageUrl(section.image_path)" :alt="section.image_alt_text">
+            </div>
+        </div>
+    </section>
+    <section v-else-if="section.layout_type==3" :class="['mb-5', fromHome ? 'album py-5 px-5 bg-light' : '']">
+        <div class="row">
+            <div class="col-md-6">
+                <!-- <img src="https://picsum.photos/600/400" alt="Large Image" class="img-fluid"> -->
+                <img :class="['img-fluid', fromHome ? 'section-layout-home' : 'section-layout-optional']" v-if="section.image_path" :src="getImageUrl(section.image_path)" :alt="section.image_alt_text">
+            </div>
+            <div class="col-md-6" v-html="section.description"></div>
+        </div>
+    </section>
+    <section v-else :class="['mb-5', fromHome ? 'album py-5 px-5 bg-light' : '']">
+        <div class="row">
+            <div class="col-md-12">
+                <img class="img-fluid" :id="fromHome ? 'section-layout-home-default' : 'section-layout-default'" v-if="section.image_path" :src="getImageUrl(section.image_path)" :alt="section.image_alt_text">
+            </div>
+            <div class="col-md-12" v-html="section.description"></div>
+        </div>
+    </section>
+</template>
+
+<script>
+export default{
+    props: ['section','fromHome'],
+    data() {
+        return {}
+    },
+    methods: {
+        getImageUrl(path) {
+            const baseUrl = process.env.VUE_APP_ASSET_BASE_URL;
+            return `${baseUrl}/storage/${path}`;
+        },
+    }
+}
+</script>
+
+<style scoped>
+    .section-layout-optional {
+        width: 600px;
+        height: 400px;
+        object-fit: cover;
+    }
+
+    #section-layout-default {
+        width: 1200px;
+        height: 500px;
+        object-fit: cover;
+    }
+
+    .section-layout-home {
+        width: 400px;
+        height: 200px;
+        object-fit: cover;
+    }
+
+    #section-layout-home-default {
+        width: 1200px;
+        height: 300px;
+        object-fit: cover;
+    }
+</style>

--- a/frontend/src/components/frontend/sections/StandardPageSectionParent.vue
+++ b/frontend/src/components/frontend/sections/StandardPageSectionParent.vue
@@ -1,0 +1,57 @@
+<template>
+    <div class="row">
+        <div class="col-md-4" v-for="childPage in childPageList" :key="childPage.id">
+            <div class="card" style="width: 18rem;">
+                <img class="img-fluid card-img-top page-card-image" v-if="childPage.image_path" :src="getImageUrl(childPage.image_path)" :alt="childPage.image_alt_text">
+                <div class="card-body">
+                    <h5 class="card-title">{{ childPage.title }}</h5>
+                    <p class="card-text" v-html="childPage.description"></p>
+                    <router-link :to="`/${childPage.slug}`" class="btn btn-primary">
+                        Read More
+                    </router-link>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import { getChildPages } from '@/services/frontendApi';
+
+export default{
+    props: ['pageId'],
+    data() {
+        return {
+            childPageList: [],
+        }
+    },
+    mounted() {
+        this.fetchChildPages();
+    },
+    methods: {
+        async fetchChildPages() {
+            await getChildPages(this.pageId)
+            .then((response) => {
+                console.log('ParentPageResponse>>', response);
+                this.childPageList = response.data.content;
+            })
+            .catch(err => {
+                console.error('Page not found', err);
+                this.$router.replace('/');
+            });
+        },
+
+        getImageUrl(path) {
+            const baseUrl = process.env.VUE_APP_ASSET_BASE_URL;
+            return `${baseUrl}/storage/${path}`;
+        },
+    }
+}
+</script>
+
+<style scoped>
+    .card-img-top {
+        height: 200px;
+        object-fit: cover;
+    }
+</style>

--- a/frontend/src/layouts/FrontendLayout.vue
+++ b/frontend/src/layouts/FrontendLayout.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="d-flex flex-column min-vh-100">
+    <FrontendHeader />
+    <main class="flex-fill my-3 container">
+      <router-view />
+    </main>
+    <FrontendFooter />
+  </div>
+</template>
+
+<script>
+import FrontendHeader from "@/components/frontend/FrontendHeader.vue";
+import FrontendFooter from "@/components/frontend/FrontendFooter.vue";
+
+export default {
+  components: {
+    FrontendHeader,
+    FrontendFooter,
+  },
+};
+</script>
+
+<style scoped>
+main {
+  padding: 20px;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -8,6 +8,10 @@ import Pages from "@/views/admin/AdminPages.vue";
 import PageForm from "@/views/admin/AdminPageForm.vue";
 import AdminLogin from "@/views/admin/auth/AdminLogin.vue";
 
+import FrontendLayout from "@/layouts/FrontendLayout.vue";
+import HomePage from "@/views/frotnend/HomePage.vue";
+import PageTheme from "@/views/frotnend/PageTheme.vue";
+
 Vue.use(Router);
 
 const router = new Router({
@@ -25,6 +29,16 @@ const router = new Router({
         { path: "", component: Dashboard },
         { path: "pages", component: Pages },
         { path: "pages/new", component: PageForm }
+      ]
+    },
+    {
+      path: "/",
+      component: FrontendLayout,
+      meta: { requiresAuth: false },
+      children: [
+        { path: "", component: HomePage },
+        // { path: "theme", component: PageTheme },
+        { path: ":slug", component: PageTheme, props: true } 
       ]
     },
     { path: "*", redirect: "/login" }, // Redirect to Login page if not authorised

--- a/frontend/src/services/frontendApi.js
+++ b/frontend/src/services/frontendApi.js
@@ -1,0 +1,20 @@
+import axios from 'axios';
+
+const API_URL = process.env.VUE_APP_ROOT_API;
+const API_HEADER = {
+  headers: {
+    Accept: 'application/json',
+  }
+};
+
+export function getPageBySlug(slug) {
+    return axios.get(`${API_URL}/${slug}`, API_HEADER);
+}
+
+export function getChildPages(id) {
+    return axios.get(`${API_URL}/parent/${id}/childs`, API_HEADER);
+}
+
+export function getHomePageSectionData() {
+    return axios.get(`${API_URL}/home`, API_HEADER);
+}

--- a/frontend/src/services/page.js
+++ b/frontend/src/services/page.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 const API_URL = process.env.VUE_APP_ROOT_API;
 const AUTH_HEADER = {
   headers: {
+    Accept: 'application/json',
     Authorization: `Bearer ${localStorage.getItem('auth_token')}`
   }
 };

--- a/frontend/src/views/admin/AdminPageForm.vue
+++ b/frontend/src/views/admin/AdminPageForm.vue
@@ -94,7 +94,7 @@
 
           <div class="row mb-3" v-if="!form.is_parent">
               <div class="d-flex justify-content-md-end mb-3">
-                  <button class="btn btn-primary btn-sm" @click="addSection">Add Section</button>
+                  <button type="button" class="btn btn-primary btn-sm" @click="addSection">Add Section</button>
               </div>
               <!-- Section: Accordion -->
               <div class="accordion" id="accordionPanelsStayOpenExample">
@@ -321,18 +321,18 @@ export default {
           }
         });
 
-        // Debug contents of formData
-        for (let [key, value] of formData.entries()) {
-          console.log(`${key}:`, value);
-        }
-
         savePage(formData)
-        .then(() => {
-          console.log('test');
-          // this.$router.push('/admin/pages');
+        .then((response) => {
+          console.log('response>>', response.status);
+          if(response.data.code == 200) {
+            this.$router.push('/admin/pages');
+          } else {
+            alert(response.data.message);
+          }
         })
         .catch(err => {
           console.error('Failed to save page:', err);
+          alert(err);
         });
       }
     },

--- a/frontend/src/views/frotnend/HomePage.vue
+++ b/frontend/src/views/frotnend/HomePage.vue
@@ -1,0 +1,89 @@
+<template>
+  <div>
+    <!-- Hero / Slider Section -->
+    <!-- <section class="hero-section mb-5">
+      <div id="carouselExampleIndicators" class="carousel slide" data-bs-ride="carousel">
+            <div class="carousel-indicators">
+                <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
+                <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="1" aria-label="Slide 2"></button>
+                <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="2" aria-label="Slide 3"></button>
+            </div>
+            <div class="carousel-inner">
+                <div class="carousel-item active">
+                    <img src="https://via.placeholder.com/700x260?text=Slide+2" class="d-block w-100" alt="Slide 1">
+                    <div class="carousel-caption d-none d-md-block">
+                        <h5>Slider URL</h5>
+                        <p><button type="button" class="btn btn-outline-info">Redirect</button></p>
+                    </div>
+                </div>
+                <div class="carousel-item">
+                    <img src="https://via.placeholder.com/700x260?text=Slide+1" class="d-block w-100" alt="Slide 2">
+                </div>
+                    <div class="carousel-item">
+                <img src="https://via.placeholder.com/700x260?text=Slide+3" class="d-block w-100" alt="Slide 3">
+                </div>
+            </div>
+            <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Previous</span>
+            </button>
+            <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide="next">
+                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Next</span>
+            </button>
+        </div>
+    </section> -->
+
+    <!-- Single Page Sections -->
+    <HomePageSectionSingle v-if="singlePageList.length" :singlePageList="singlePageList" />
+    <!-- Parent Page Sections -->
+    <HomePageSectionParent v-if="parentChildPageList.length" :parentPageList="parentChildPageList" />
+  </div>
+</template>
+
+<script>
+import { getHomePageSectionData } from '@/services/frontendApi';
+import HomePageSectionSingle from "@/components/frontend/sections/HomePageSectionSingle.vue";
+import HomePageSectionParent from "@/components/frontend/sections/HomePageSectionParent.vue";
+
+export default{
+    props: ['pageId'],
+    components: {
+        HomePageSectionSingle,
+        HomePageSectionParent,
+    },
+    data() {
+        return {
+            singlePageList: [],
+            parentChildPageList: [],
+        }
+    },
+    beforeMount() {
+        this.fetchSectionData();
+    },
+    methods: {
+        async fetchSectionData() {
+            await getHomePageSectionData()
+            .then((response) => {
+                const data = response.data.content;
+                this.singlePageList = data.single;
+                this.parentChildPageList = data.parent;
+
+                console.log('singlePageList>>', this.singlePageList);
+                console.log('parentChildPageList>>', this.parentChildPageList);
+            })
+            .catch(err => {
+                console.error('Page not found', err);
+                this.$router.replace('/');
+            });
+        },
+    }
+}
+</script>
+
+<style scoped>
+    .card-img-top {
+        height: 200px;
+        object-fit: cover;
+    }
+</style>

--- a/frontend/src/views/frotnend/PageTheme.vue
+++ b/frontend/src/views/frotnend/PageTheme.vue
@@ -1,0 +1,66 @@
+<template>
+    <div>
+        <Breadcrumb v-if="page && page.title" :title="page.title" :breadcrumb="breadcrumb" />
+
+        <div v-if="page.is_parent==1">
+            <StandardPageSectionParent :pageId="page.id" /> <!-- Use loop for its child i.e. data coming from page -->
+        </div>
+        <div v-else>
+            <div v-for="section in sectionList" :key="section.id">
+                <StandardPageSection :section="section" :fromHome="false" />
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import StandardPageSection from "@/components/frontend/sections/StandardPageSection.vue";
+import StandardPageSectionParent from "@/components/frontend/sections/StandardPageSectionParent.vue";
+import Breadcrumb from "@/components/frontend/FrontendBreadcrumb.vue";
+import { getPageBySlug } from '@/services/frontendApi';
+
+export default {
+    props: ["slug"],
+    components: {
+        Breadcrumb,
+        StandardPageSection,
+        StandardPageSectionParent
+    },
+
+    data() {
+        return {
+            breadcrumb: [
+                { name: "Home", path: "/" },
+            ],
+            page: {},
+            sectionList: []
+        }
+    },
+
+    methods: {
+        async fetchPage() {
+            await getPageBySlug(this.slug)
+            .then((response) => {
+                const data = response.data.content;
+                if(data.sections) {
+                    this.sectionList = data.sections;
+                }
+                this.page = data;
+            })
+            .catch(err => {
+                console.error('Page not found', err);
+                this.$router.replace('/');
+            });
+        }
+    },
+
+    watch: {
+        slug: {
+            immediate: true,
+            handler(newSlug) {
+                this.fetchPage(newSlug);
+            }
+        }
+    },
+}
+</script>

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Admin\PageController;
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\Frontend\PageController as FrontendPageController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/login', [AuthController::class, 'login']);
@@ -20,3 +21,7 @@ Route::middleware('auth:sanctum')->group(function () {
     });
     Route::get('/parent/pages', [PageController::class, 'parentPages']);
 });
+
+Route::get('/home', [FrontendPageController::class, 'getHomePageSections']);
+Route::get('/parent/{id}/childs', [FrontendPageController::class, 'getChildPages']);
+Route::get('/{slug}', [FrontendPageController::class, 'showPage'])->where('slug', '.*');


### PR DESCRIPTION
**Backend**
- Created Frontend/PageController to handle frontend-related page functionality
- Added the following methods:
    - showPage() – renders individual pages
    - getChildPages() – retrieves and renders child pages of a parent
    - getHomePageSections() – renders all pages with add_to_home = true
- Defined routes for the above methods
- Created Traits/RequestResponseTrait to standardize success and error responses
- Integrated RequestResponseTrait in both Frontend/PageController and Backend/PageController for consistent API responses

**Frontend**
-  Created a basic frontend template using a FrontendLayout which includes:
    - FrontendHeader: for navigation bar
    - FrontendFooter: for footer section
    - FrontendBreadcrumb: for breadcrumb navigation
- Created frontendAPi.js service file to handle Axios calls to the frontend APIs
- Created PageTheme view file to render individual and child pages using:
    - StandardPageSection: layout for single and child pages
    - StandardPageSectionParent: layout for parent pages listing their children
- Created HomePage view file to to render the home page using:
    - HomePageSectionParent: displays parent pages and their child pages
    - HomePageSectionSingle: displays standalone pages using their defined layout type

**Bug Fixing**
- Fixed issue in the admin panel page form where clicking "Add Section" would accidentally submit the form and save incomplete data
    - Solution: Changed button type to button to prevent unintentional form submission