### PR TITLE
Handle Dynamic Menu & Parent Child Breadcrumb

### DIFF
--- a/app/Http/Controllers/Frontend/PageController.php
+++ b/app/Http/Controllers/Frontend/PageController.php
@@ -122,4 +122,34 @@ class PageController extends Controller
             'image_alt_text' => $media->alt_text ?? null,
         ];
     }
+
+    public function getMenuPages()
+    {
+        try {
+            $menuPages = Page::select('id', 'title', 'slug')
+                ->where('is_menu', true)
+                ->whereNull('parent_id')
+                ->orderBy('order', 'asc')
+                ->with(['children' => function ($q) {
+                    $q->select('id', 'title', 'slug', 'parent_id')
+                    ->where('is_menu', true)
+                    ->orderBy('order', 'asc');
+                }])
+                ->get();
+
+            return response()->json([
+                'code' => 200,
+                'status' => 'success',
+                'message' => 'Menu pages fetched successfully.',
+                'content' => $menuPages
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'code' => 500,
+                'status' => 'error',
+                'message' => 'Something went wrong.',
+                'content' => $e->getMessage()
+            ]);
+        }
+    }
 }

--- a/app/Http/Controllers/Frontend/PageController.php
+++ b/app/Http/Controllers/Frontend/PageController.php
@@ -15,13 +15,15 @@ class PageController extends Controller
     public function showPage($slug)
     {
         try {
-            $page = Page::select('id', 'title', 'slug', 'is_parent')->where('slug', $slug)->with(['sections:id,page_id,layout_type,description,media_id','sections.media:id,path,alt_text'])->firstOrFail();
+            $page = Page::select('id', 'title', 'slug', 'is_parent', 'parent_id')->where('slug', $slug)->with(['sections:id,page_id,layout_type,description,media_id','sections.media:id,path,alt_text','parent:id,title,slug'])->firstOrFail();
 
             $data = [];
             $data['id'] = $page->id;
             $data['title'] = $page->title;
             $data['slug'] = $page->slug;
             $data['is_parent'] = $page->is_parent;
+            $data['parent_title'] = $page->parent->title ?? null;
+            $data['parent_slug'] = $page->parent->slug ?? null;
 
             foreach($page->sections as $section) {
                 $data['sections'][] = [

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -30,6 +30,11 @@ class Page extends Model
         return $this->hasMany(PageSections::class);
     }
 
+    public function parent()
+    {
+        return $this->hasOne(Page::class, 'id', 'parent_id');
+    }
+
     public function children()
     {
         return $this->hasMany(Page::class, 'parent_id');

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -29,4 +29,9 @@ class Page extends Model
     public function sections() {
         return $this->hasMany(PageSections::class);
     }
+
+    public function children()
+    {
+        return $this->hasMany(Page::class, 'parent_id');
+    }
 }

--- a/frontend/src/components/frontend/FrontendHeader.vue
+++ b/frontend/src/components/frontend/FrontendHeader.vue
@@ -13,45 +13,107 @@
       >
         <span class="navbar-toggler-icon"></span>
       </button>
+
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
           <li class="nav-item">
-            <router-link :to="`/`" class="nav-link active">
-                Home
+            <router-link
+              :to="`/`"
+              class="nav-link"
+              :class="{ active: $route.path === '/' }"
+            >
+              Home
             </router-link>
+
           </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#">Link</a>
-          </li>
-          <li class="nav-item dropdown">
+          
+          <li
+            v-for="page in parentMenuPages"
+            :key="'parent-' + page.id"
+            class="nav-item dropdown"
+            :class="{ active: isParentActive(page) }"
+          >
             <a
               class="nav-link dropdown-toggle"
               href="#"
-              id="navbarDropdown"
+              :id="`dropdown-${page.id}`"
               role="button"
               data-bs-toggle="dropdown"
               aria-expanded="false"
             >
-              Dropdown
+              {{ page.title }}
             </a>
-            <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-              <li><a class="dropdown-item" href="#">Action</a></li>
-              <li><a class="dropdown-item" href="#">Another action</a></li>
-              <li><hr class="dropdown-divider" /></li>
-              <li><a class="dropdown-item" href="#">Something else here</a></li>
+            <ul class="dropdown-menu" :aria-labelledby="`dropdown-${page.id}`">
+              <li
+                v-for="child in page.children"
+                :key="'child-' + child.id"
+              >
+                <router-link
+                  class="dropdown-item"
+                  :to="`/${child.slug}`"
+                  active-class="active"
+                >
+                  {{ child.title }}
+                </router-link>
+              </li>
             </ul>
           </li>
-          <li class="nav-item">
-            <a
-              class="nav-link disabled"
-              href="#"
-              tabindex="-1"
-              aria-disabled="true"
-              >Disabled</a
-            >
+          <li
+            v-for="page in singleMenuPages"
+            :key="'single-' + page.id"
+            class="nav-item"
+          >
+            <router-link :to="`/${page.slug}`" class="nav-link" active-class="active">
+              {{ page.title }}
+            </router-link>
           </li>
         </ul>
       </div>
     </div>
   </nav>
 </template>
+
+
+<script>
+import { getMenuPages } from "@/services/frontendApi";
+
+export default {
+  data() {
+    return {
+      menuPages: [],
+    };
+  },
+  mounted() {
+    this.fetchMenuPages();
+  },
+  computed: {
+    parentMenuPages() {
+      return this.menuPages.filter(p => p.children && p.children.length);
+    },
+    singleMenuPages() {
+      return this.menuPages.filter(p => !p.children || !p.children.length);
+    },
+  },
+  methods: {
+    async fetchMenuPages() {
+      try {
+        const response = await getMenuPages();
+        this.menuPages = response.data.content;
+      } catch (err) {
+        console.error("Failed to load menu pages", err);
+      }
+    },
+    isParentActive(parentPage) {
+      const currentPath = this.$route.path;
+      return parentPage.children.some(child => `/${child.slug}` === currentPath);
+    }
+  }
+};
+</script>
+
+<style scoped>
+.navbar .nav-item.active > .nav-link {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 0.25rem;
+}
+</style>

--- a/frontend/src/services/frontendApi.js
+++ b/frontend/src/services/frontendApi.js
@@ -18,3 +18,7 @@ export function getChildPages(id) {
 export function getHomePageSectionData() {
     return axios.get(`${API_URL}/home`, API_HEADER);
 }
+
+export function getMenuPages() {
+    return axios.get(`${API_URL}/menu/pages`);
+}

--- a/frontend/src/views/admin/AdminPageForm.vue
+++ b/frontend/src/views/admin/AdminPageForm.vue
@@ -292,7 +292,7 @@ export default {
       async fetchParentPages() {
         try {
           const response = await getParentPages();
-          this.parentPages = response.data;
+          this.parentPages = response.data.content;
         } catch (error) {
           console.error("Failed to load parent pages", error);
         }

--- a/frontend/src/views/frotnend/PageTheme.vue
+++ b/frontend/src/views/frotnend/PageTheme.vue
@@ -29,9 +29,7 @@ export default {
 
     data() {
         return {
-            breadcrumb: [
-                { name: "Home", path: "/" },
-            ],
+            breadcrumb: [],
             page: {},
             sectionList: []
         }
@@ -42,6 +40,7 @@ export default {
             await getPageBySlug(this.slug)
             .then((response) => {
                 const data = response.data.content;
+                this.updateBreadcrumb(data);
                 if(data.sections) {
                     this.sectionList = data.sections;
                 }
@@ -51,6 +50,16 @@ export default {
                 console.error('Page not found', err);
                 this.$router.replace('/');
             });
+        },
+        updateBreadcrumb(data) {
+            this.breadcrumb = [
+                { name: "Home", path: "/" },
+            ];
+            if(!data.is_parent && data.parent_title != null) {
+                this.breadcrumb.push(
+                    {name: data.parent_title, path: '/'+data.parent_slug}
+                );
+            }
         }
     },
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,5 +23,6 @@ Route::middleware('auth:sanctum')->group(function () {
 });
 
 Route::get('/home', [FrontendPageController::class, 'getHomePageSections']);
+Route::get('/menu/pages', [FrontendPageController::class, 'getMenuPages']);
 Route::get('/parent/{id}/childs', [FrontendPageController::class, 'getChildPages']);
 Route::get('/{slug}', [FrontendPageController::class, 'showPage'])->where('slug', '.*');


### PR DESCRIPTION
**Backend**
- Added the getMenuPages() method into the Frontend/PageController to retrieve and render pages where is_menu=true for use in the navigation menu
- Extended the query to show the relationship of page with its parent page if it have id on parent_id. This query is use to display the parent page title into the Breadcrumb
- Added Eloquent relationships in the Page model:
    - parent() – defines a hasOne relationship to get the parent page of a given page
    - children() – defines a hasMany relationship to retrieve all child pages of a given page
- Defined the route for getMenuPages to retrieve the menu data via API

**Frontend**
- Made the navigation bar in FrontendHeader dynamic by listing all pages where is_menu = true
- Updated breadcrumb logic in PageTheme:
   - If the page has a parent, display breadcrumb as: Home / Parent Title / Child Title
   - Otherwise display as: Home / Page Title
- Added getMenuPages() method in frontendApi.js to handle Axios calls for retrieving menu data