### PR TITLE
Add OverlayLoaderComponent For Frontend, Add Loader On Remaining Module Of Admin Panel & Bugfix

### DIFF
--- a/frontend/src/components/OverlayLoaderComponent.vue
+++ b/frontend/src/components/OverlayLoaderComponent.vue
@@ -1,0 +1,68 @@
+<template>
+  <div v-if="visible" class="overlay-loader">
+    <div class="cube-loader">
+      <div class="cube"></div>
+      <div class="cube"></div>
+      <div class="cube"></div>
+      <div class="cube"></div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    visible: {
+      type: Boolean,
+      required: true
+    }
+  }
+};
+</script>
+
+<style scoped>
+.overlay-loader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 9999;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(255, 255, 255, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cube-loader {
+  width: 60px;
+  height: 60px;
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.cube {
+  width: 25px;
+  height: 25px;
+  background-color: #007bff;
+  animation: cubeFade 1.2s infinite ease-in-out;
+}
+
+.cube:nth-child(1) { animation-delay: 0s; }
+.cube:nth-child(2) { animation-delay: 0.2s; }
+.cube:nth-child(3) { animation-delay: 0.4s; }
+.cube:nth-child(4) { animation-delay: 0.6s; }
+
+@keyframes cubeFade {
+  0%, 100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(0.5);
+    opacity: 0.3;
+  }
+}
+</style>

--- a/frontend/src/components/frontend/sections/HomePageSectionParent.vue
+++ b/frontend/src/components/frontend/sections/HomePageSectionParent.vue
@@ -1,23 +1,25 @@
 <template>
      <div>
         <section class="page-sections container mb-5" v-for="childPageList in parentPageList" :key="childPageList.parent_id">
-            <div class="row mb-3">
-                <div class="d-flex justify-content-center">
-                    <span class="border-bottom border-info-subtle border-5 bg-light ps-2"><h2>{{ childPageList.parent_page_title }}</h2></span>
+            <template v-if="childPageList.children.length">
+                <div class="row mb-3">
+                    <div class="d-flex justify-content-center">
+                        <span class="border-bottom border-info-subtle border-5 bg-light ps-2"><h2>{{ childPageList.parent_page_title }}</h2></span>
+                    </div>
                 </div>
-            </div>
-            <div class="row album py-5 px-5 bg-light">
-                <div class="col-md-4" v-for="childPage in childPageList.children" :key="childPage.id">
-                    <div class="card" style="width: 18rem;">
-                        <img class="img-fluid card-img-top page-card-image" v-if="childPage.image_path" :src="getImageUrl(childPage.image_path)" :alt="childPage.image_alt_text">
-                        <div class="card-body">
-                            <h5 class="card-title">{{ childPage.title }}</h5>
-                            <p class="card-text" v-html="childPage.description"></p>
-                            <router-link :to="childPage.slug" class="btn btn-primary">{{ buttonName }}</router-link>
+                <div class="row album py-5 px-5 bg-light">
+                    <div class="col-md-4" v-for="childPage in childPageList.children" :key="childPage.id">
+                        <div class="card" style="width: 18rem;">
+                            <img class="img-fluid card-img-top page-card-image" v-if="childPage.image_path" :src="getImageUrl(childPage.image_path)" :alt="childPage.image_alt_text">
+                            <div class="card-body">
+                                <h5 class="card-title">{{ childPage.title }}</h5>
+                                <p class="card-text" v-html="childPage.description"></p>
+                                <router-link :to="childPage.slug" class="btn btn-primary">{{ buttonName }}</router-link>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
+            </template>
         </section>
      </div>
 </template>

--- a/frontend/src/views/admin/AdminDashboard.vue
+++ b/frontend/src/views/admin/AdminDashboard.vue
@@ -2,7 +2,8 @@
     <div>
         <Breadcrumb :title="'Dashboard'" :breadcrumb="breadcrumb" />
 
-        <div class="container py-4">
+        <LoaderComponent v-if="isLoading" />
+        <div class="container py-4" v-else>
             <div class="row g-4">
                 <!-- Card 1 -->
                 <div v-for="(card, index) in dashboardData" :key="index" class="col-md-3">
@@ -25,11 +26,13 @@
 
 <script>
 import Breadcrumb from "../../components/admin/AdminBreadcrumb.vue";
+import LoaderComponent from "../../components/LoaderComponent.vue";
 import { getRecords } from '@/services/dashboard';
 
 export default {
     components: {
         Breadcrumb,
+        LoaderComponent
     },
     data() {
         return {
@@ -37,22 +40,24 @@ export default {
                 { name: "Admin", path: "/admin" },
             ],
             dashboardData: [],
+            isLoading: false,
         }
     },
     mounted() {
-        console.log('yes');
         this.dashboardRecords();
     },
     methods: {
         dashboardRecords() {
-            console.log('inside');
+            this.isLoading = true;
             getRecords()
             .then((response) => {
-                console.log('response>>', response);
                 this.dashboardData = response.data.content;
             })
             .catch((e) => {
                 console.log('Error!!', e);
+            })
+            .finally(() => {
+                this.isLoading = false;
             })
         }
     }

--- a/frontend/src/views/admin/GeneralSettings.vue
+++ b/frontend/src/views/admin/GeneralSettings.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <Breadcrumb :title="'Settings'" :breadcrumb="breadcrumb" />
-    <div class="card mb-4">
+
+    <LoaderComponent v-if="isLoading" />
+    <div class="card mb-4" v-else>
       <div class="card-header d-flex align-items-center justify-content-between">
         <div>
           <i class="fas fa-cog me-1"></i>
@@ -77,17 +79,20 @@
 
 <script>
 import Breadcrumb from "../../components/admin/AdminBreadcrumb.vue";
+import LoaderComponent from "../../components/LoaderComponent.vue";
 import { getAllSettings, updateSettings } from "@/services/setting";
 
 export default {
   components: {
     Breadcrumb,
+    LoaderComponent
   },
   data() {
     return {
       breadcrumb: [{ name: "Admin", path: "/admin" }],
       settingsForm: [],
       previewUrl: null,
+      isLoading: false,
       themesOption: [
         { text: "Primary", value: "bg-primary" },
         { text: "Secondary", value: "bg-secondary" },
@@ -118,6 +123,7 @@ export default {
         return null;
     },
     fetchSettings() {
+      this.isLoading = true;
       getAllSettings()
         .then((response) => {
           const data = response.data;
@@ -132,9 +138,13 @@ export default {
         .catch((err) => {
           console.error("Failed To List Settings:", err);
           alert(err);
-        });
+        })
+        .finally(() => {
+          this.isLoading = false;
+        })
     },
     saveSettings() {
+      this.isLoading = true;
       const formData = new FormData();
       Object.entries(this.settingsForm).forEach(([key, value]) => {
         if (value instanceof File) {
@@ -155,7 +165,10 @@ export default {
         .catch((err) => {
           console.error("Error saving settings:", err);
           alert("Error saving settings");
-        });
+        })
+        .finally(() => {
+          this.isLoading = false;
+        })
     },
   },
 };

--- a/frontend/src/views/frotnend/HomePage.vue
+++ b/frontend/src/views/frotnend/HomePage.vue
@@ -1,12 +1,13 @@
 <template>
-  <div>
-    <!-- Hero / Slider Section -->
-    <SliderSection :sliderList="sliderList" />
-    <!-- Single Page Sections -->
-    <HomePageSectionSingle v-if="singlePageList.length" :singlePageList="singlePageList" />
-    <!-- Parent Page Sections -->
-    <HomePageSectionParent v-if="parentChildPageList.length" :parentPageList="parentChildPageList" />
-  </div>
+    <div v-if=!isLoading>
+        <!-- Hero / Slider Section -->
+        <SliderSection :sliderList="sliderList" />
+        <!-- Single Page Sections -->
+        <HomePageSectionSingle v-if="singlePageList.length" :singlePageList="singlePageList" />
+        <!-- Parent Page Sections -->
+        <HomePageSectionParent v-if="parentChildPageList.length" :parentPageList="parentChildPageList" />
+    </div>
+    <OverlayLoader v-else :visible="isLoading" />
 </template>
 
 <script>
@@ -14,19 +15,22 @@ import { getHomePageSectionData } from '@/services/frontendApi';
 import HomePageSectionSingle from "@/components/frontend/sections/HomePageSectionSingle.vue";
 import HomePageSectionParent from "@/components/frontend/sections/HomePageSectionParent.vue";
 import SliderSection from "@/components/frontend/sections/SliderSection.vue";
+import OverlayLoader from '@/components/OverlayLoaderComponent.vue';
 
 export default{
     props: ['pageId'],
     components: {
         HomePageSectionSingle,
         HomePageSectionParent,
-        SliderSection
+        SliderSection,
+        OverlayLoader
     },
     data() {
         return {
             singlePageList: [],
             parentChildPageList: [],
             sliderList: [],
+            isLoading: false,
         }
     },
     beforeMount() {
@@ -34,6 +38,7 @@ export default{
     },
     methods: {
         async fetchSectionData() {
+            this.isLoading = true;
             await getHomePageSectionData()
             .then((response) => {
                 const data = response.data.content;
@@ -46,6 +51,11 @@ export default{
             .catch(err => {
                 console.error('Page not found', err);
                 this.$router.replace('/');
+            })
+            .finally(() => {
+                this.$nextTick(() => {
+                    this.isLoading = false;
+                });
             });
         },
     }

--- a/frontend/src/views/frotnend/PageTheme.vue
+++ b/frontend/src/views/frotnend/PageTheme.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div v-if=!isLoading>
         <Breadcrumb v-if="page && page.title" :title="page.title" :breadcrumb="breadcrumb" />
 
         <div v-if="page.is_parent==1">
@@ -11,6 +11,7 @@
             </div>
         </div>
     </div>
+    <OverlayLoader v-else :visible="isLoading" />
 </template>
 
 <script>
@@ -18,25 +19,29 @@ import StandardPageSection from "@/components/frontend/sections/StandardPageSect
 import StandardPageSectionParent from "@/components/frontend/sections/StandardPageSectionParent.vue";
 import Breadcrumb from "@/components/frontend/FrontendBreadcrumb.vue";
 import { getPageBySlug } from '@/services/frontendApi';
+import OverlayLoader from '@/components/OverlayLoaderComponent.vue';
 
 export default {
     props: ["slug"],
     components: {
         Breadcrumb,
         StandardPageSection,
-        StandardPageSectionParent
+        StandardPageSectionParent,
+        OverlayLoader
     },
 
     data() {
         return {
             breadcrumb: [],
             page: {},
-            sectionList: []
+            sectionList: [],
+            isLoading: false,
         }
     },
 
     methods: {
         async fetchPage() {
+            this.isLoading = true;
             await getPageBySlug(this.slug)
             .then((response) => {
                 const data = response.data.content;
@@ -49,6 +54,9 @@ export default {
             .catch(err => {
                 console.error('Page not found', err);
                 this.$router.replace('/');
+            })
+            .finally(() => {
+                this.isLoading = false;
             });
         },
         updateBreadcrumb(data) {


### PR DESCRIPTION
**Add OverlayLoaderComponent For Frontend**
- Create OverlayLoaderComponent
- Integrate OverlayLoaderComponent with frontend pages like Home Page & Other  dynamic pages

**Add Loader On Remaining Module Of Admin Panel**
- Add Loader in Dashboard Page
- Add Loader in Settings Page

**Bug Fix**
- At home page when the page is set to add_to_home, pages were not displayed at home page due to wrong query. So, fix the query and line of codes to get right data.
- Fix the display at home for parent pages only if it contain child otherwise not to display